### PR TITLE
feat: Dockerize frontend application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,58 @@
+# Git
+.git
+.gitignore
+
+# Node modules
+node_modules
+
+# Bun-specific cache and logs (if any become prominent)
+.bun
+
+# Build output - this is generated inside the Docker image
+dist
+build
+out
+
+# Docker specific files
+Dockerfile
+docker-compose.yml # if you add one later
+*.dockerignore
+
+# OS-specific
+.DS_Store
+Thumbs.db
+
+# IDE specific
+.vscode
+.idea
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+bun-debug.log* # Example, if Bun produces such logs
+
+# Local environment variables file - if not explicitly copied in Dockerfile
+# In our case, .env IS copied in the Dockerfile for Vite build, so we DON'T ignore it here.
+# If you change strategy to pass env vars at container runtime instead of build time, then add .env here.
+# # .env
+
+# Test files and coverage reports (if not needed in image)
+coverage
+src/**/*.test.tsx
+src/**/*.test.ts
+src/**/*.spec.tsx
+src/**/*.spec.ts
+
+# Storybook specific (if used)
+.storybook
+storybook-static
+
+# Lint and format cache files
+.eslintcache
+.prettiercache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Stage 1: Build the application using Bun
+FROM oven/bun:1 as builder
+
+WORKDIR /app
+
+# Copy package.json and bun.lockb
+COPY package.json bun.lockb ./
+
+# Install dependencies
+RUN bun install --frozen-lockfile
+
+# Copy the rest of the application code
+COPY . .
+
+# Copy the .env file for build-time environment variables
+# IMPORTANT: Ensure your .env file is present in the build context
+# and contains the VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY
+COPY .env .env
+
+# Build the application
+RUN bun run build
+
+# Stage 2: Serve the application using Nginx
+FROM nginx:1.25-alpine as server
+
+# Set working directory for Nginx
+WORKDIR /usr/share/nginx/html
+
+# Remove default Nginx static assets
+RUN rm -rf ./*
+
+# Copy static assets from builder stage
+COPY --from=builder /app/dist .
+
+# Copy custom Nginx configuration (will be created in the next step)
+# This nginx.conf should handle SPA routing (e.g., try_files $uri $uri/ /index.html;)
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Expose port 80
+EXPOSE 80
+
+# Start Nginx
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,28 @@
+server {
+    listen 80;
+    server_name localhost; # Or your domain
+
+    # Root directory for static files, matches Dockerfile WORKDIR and COPY destination
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+
+    # Include standard mime types
+    include /etc/nginx/mime.types;
+
+    location / {
+        # Try to serve file directly, then directory, then fall back to index.html for SPA routing
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Optional: Add caching headers for static assets to improve performance
+    # location ~* \.(?:css|js|jpg|jpeg|gif|png|ico|svg|woff|woff2|ttf|eot)$ {
+    #     expires 1y;
+    #     add_header Cache-Control "public";
+    # }
+
+    # Optional: Add security headers
+    # add_header X-Frame-Options "SAMEORIGIN";
+    # add_header X-XSS-Protection "1; mode=block";
+    # add_header X-Content-Type-Options "nosniff";
+    # add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "docker:build": "docker build -t resumerise-app .",
+    "docker:run": "docker run -p 8080:80 resumerise-app"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
This commit introduces Docker configuration to build and run the frontend Vite/React application in a containerized environment.

Key additions:

1.  **`Dockerfile`:**
    *   A multi-stage Dockerfile.
    *   Stage 1 (builder): Uses `oven/bun:1` to install dependencies (`bun install --frozen-lockfile`), copy application source code (including `.env` for Vite's build-time environment variable replacement), and build the static assets (`bun run build`).
    *   Stage 2 (server): Uses `nginx:1.25-alpine` to serve the built static assets. It copies the `dist` folder from the builder stage and uses a custom Nginx configuration.

2.  **`nginx.conf`:**
    *   Custom Nginx configuration to serve the Single Page Application (SPA).
    *   Listens on port 80.
    *   Includes `try_files` directive to ensure all routes are correctly handled by `index.html` for client-side routing.

3.  **`.dockerignore`:**
    *   Specifies files and directories to exclude from the Docker build context, optimizing build time and image size.
    *   Crucially, it does *not* ignore the `.env` file, allowing it to be copied in the `Dockerfile` for the Vite build process.

4.  **`package.json` scripts:**
    *   Added `docker:build` script (`docker build -t resumerise-app .`) to build the image.
    *   Added `docker:run` script (`docker run -p 8080:80 resumerise-app`) to run the container, mapping port 8080 on your host to port 80 in the container.

This setup allows for easier local testing and provides a consistent deployment artifact for the frontend application. You are responsible for ensuring your `.env` file is correctly populated with Supabase credentials before building the Docker image.